### PR TITLE
Fix MAX_HEARTBEAT_GAP_SEC member mis-named

### DIFF
--- a/python/oatmeal/protocol.py
+++ b/python/oatmeal/protocol.py
@@ -1061,7 +1061,7 @@ class OatmealBgMsgHandlerBase(ABC):
 
     @property
     @abstractmethod
-    def MAX_HEARTBEAT_GAP_SEC(self) -> float:
+    def MAX_HEARTBEAT_GAP_SEC(self) -> Optional[float]:
         """
         Defines the maximum time that is permitted to pass without a heartbeat
         (or log message) before a heartbeat is considered to have been missed

--- a/python/oatmeal/protocol.py
+++ b/python/oatmeal/protocol.py
@@ -1066,6 +1066,7 @@ class OatmealBgMsgHandlerBase(ABC):
         Defines the maximum time that is permitted to pass without a heartbeat
         (or log message) before a heartbeat is considered to have been missed
         and :meth:`OatmealBgMsgHandler.missing_heartbeat()` is called.
+        If set to None, no background messages are expected.
         """
         raise NotImplementedError
 

--- a/python/oatmeal/protocol.py
+++ b/python/oatmeal/protocol.py
@@ -1061,7 +1061,7 @@ class OatmealBgMsgHandlerBase(ABC):
 
     @property
     @abstractmethod
-    def max_gap_sec(self) -> float:
+    def MAX_HEARTBEAT_GAP_SEC(self) -> float:
         """
         Defines the maximum time that is permitted to pass without a heartbeat
         (or log message) before a heartbeat is considered to have been missed


### PR DESCRIPTION
This variable was misnamed and expanded to allow `None`. This abstract class member was missed. It was caught by mypy checks in another project when we tried to instantiate it.