### PR TITLE
Fix filename in library.properties includes field

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=The protocol supports multiple data types including integers, strings,
 category=Communication
 url=https://github.com/shielddx/oatmeal-protocol
 architectures=*
-includes=oatemal_protocol.h
+includes=oatmeal_protocol.h


### PR DESCRIPTION
The `includes` field of library.properties defines the filenames for which `#include directives` should be added to the sketch via **Sketch > Include Library > OatmealProtocol**. Incorrect filename in this field results in the sketch failing to compile with a "no such file or directory" error.