### PR TITLE
List pyserial in install_requires

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -14,6 +14,9 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/shielddx/oatmeal-protocol",
     packages=setuptools.find_packages(),
+    install_requires=[
+        'pyserial',
+    ],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
I thought at first that maybe it made sense to somehow reference our existing requirements.txt, but https://stackoverflow.com/a/33685899/1709587 makes a decent case that actually it's reasonable to duplicate these requirements and specify versions in the requirements.txt but not in the setup.py. So this solution seems fine.

@noporpoise this fixes the issue @MapleTronix noticed and told us about on WhatsApp. You'll need to deploy to PyPI, or grant me (https://pypi.org/user/ExplodingCabbage/) permission to upload new versions.